### PR TITLE
Fixes for the balance board and synchronous expansion handshake

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -211,6 +211,7 @@ void propagate_event(struct wiimote_t* wm, byte event, byte* msg) {
 				/* don't execute the event callback */
 				return;
 			}
+		case WM_RPT_BTN_EXP_8:
 		case WM_RPT_BTN_EXP: {
 				/* button - expansion */
 				wiiuse_pressed_buttons(wm, msg);

--- a/src/events.c
+++ b/src/events.c
@@ -263,8 +263,17 @@ void propagate_event(struct wiimote_t* wm, byte event, byte* msg) {
 
 				break;
 			}
+
+		/*
+		 * FIXME: this gets triggered only when the Wiimote sends 0x22
+		 * Acknowledge output report, return function result. This is unfortunately sent only
+		 * rarely, typically when there is an error (e.g. reading from an invalid address) and
+		 * *must not* be relied on to call the write callbacks. The report can also appear unsolicited
+		 * during synchronous handshake, where it would produce spurious error messages. That's why
+		 * it is disabled.
+		 */
 		case WM_RPT_WRITE: {
-				event_data_write(wm, msg);
+				/* event_data_write(wm, msg); */
 				break;
 			}
 		default: {
@@ -536,7 +545,7 @@ static void event_status(struct wiimote_t* wm, byte* msg) {
 	/* expansion port */
 	if (attachment && !WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP) && !WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP_HANDSHAKE)) {
 		/* send the initialization code for the attachment */
-		handshake_expansion(wm, NULL, 0);
+ 		handshake_expansion(wm, NULL, 0);
 		exp_changed = 1;
 	} else if (!attachment && WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP)) {
 		/* attachment removed */
@@ -556,13 +565,16 @@ static void event_status(struct wiimote_t* wm, byte* msg) {
 	 *	We need to send a WIIMOTE_CMD_REPORT_TYPE packet to
 	 *	reenable other incoming reports.
 	 */
-	if (exp_changed && WIIMOTE_IS_SET(wm, WIIMOTE_STATE_IR)) {
-		/*
-		 *  Since the expansion status changed IR needs to
-		 *  be reset for the new IR report mode.
-		 */
-		WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_IR);
-		wiiuse_set_ir(wm, 1);
+	if (exp_changed)
+	{
+	    if (WIIMOTE_IS_SET(wm, WIIMOTE_STATE_IR)) {
+            /*
+             *  Since the expansion status changed IR needs to
+             *  be reset for the new IR report mode.
+             */
+            WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_IR);
+            wiiuse_set_ir(wm, 1);
+	    }
 	} else {
 		wiiuse_set_report_type(wm);
 		return;
@@ -632,6 +644,104 @@ void handshake_expansion(struct wiimote_t* wm, byte* data, uint16_t len) {
 	byte buf = 0x00;
 	byte* handshake_buf;
 	int gotIt = 0;
+
+	/*
+	 * phase 1 - write 0x55 to init expansion
+	 */
+    wm->expansion_state = 1;
+#ifdef WIIUSE_WIN32
+    /* increase the timeout until the handshake completes */
+    WIIUSE_DEBUG("write 0x55 - Setting timeout to expansion %i ms.", wm->exp_timeout);
+    wm->timeout = wm->exp_timeout;
+#endif
+    buf = 0x55;
+    wiiuse_write_data(wm, WM_EXP_MEM_ENABLE1, &buf, 1);
+
+    /*
+     * phase 2 - write 0x00 to init expansion
+     */
+    wm->expansion_state = 2;
+#ifdef WIIUSE_WIN32
+        /* increase the timeout until the handshake completes */
+        WIIUSE_DEBUG("write 0x00 - Setting timeout to expansion %i ms.", wm->exp_timeout);
+        wm->timeout = wm->exp_timeout;
+#endif
+    buf = 0x00;
+    wiiuse_write_data(wm, WM_EXP_MEM_ENABLE2, &buf, 1);
+
+    /*
+     * phase 3 - get expansion ID & calibration data
+     */
+    wm->expansion_state = 3;
+    if (WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP))
+        disable_expansion(wm);
+
+    handshake_buf = malloc(EXP_HANDSHAKE_LEN * sizeof(byte));
+    /* tell the wiimote to send expansion data */
+    WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_EXP);
+    wiiuse_read_data_sync(wm, 0, WM_EXP_MEM_CALIBR,  EXP_HANDSHAKE_LEN, handshake_buf);
+
+    /*
+     * phase 4 - process the data, init the expansions
+     */
+    wm->expansion_state = 0;
+    id = from_big_endian_uint32_t(handshake_buf + 220);
+    switch (id)
+    {
+        case EXP_ID_CODE_NUNCHUK:
+            if (nunchuk_handshake(wm, &wm->exp.nunchuk, handshake_buf, EXP_HANDSHAKE_LEN)) {
+                wm->event = WIIUSE_NUNCHUK_INSERTED;
+                gotIt = 1;
+            }
+            break;
+
+        case EXP_ID_CODE_CLASSIC_CONTROLLER:
+            if (classic_ctrl_handshake(wm, &wm->exp.classic, handshake_buf, EXP_HANDSHAKE_LEN)) {
+                wm->event = WIIUSE_CLASSIC_CTRL_INSERTED;
+                gotIt = 1;
+            }
+            break;
+
+        case EXP_ID_CODE_GUITAR:
+            if (guitar_hero_3_handshake(wm, &wm->exp.gh3, handshake_buf, EXP_HANDSHAKE_LEN)) {
+                wm->event = WIIUSE_GUITAR_HERO_3_CTRL_INSERTED;
+                gotIt = 1;
+            }
+            break;
+
+        case EXP_ID_CODE_MOTION_PLUS:
+        case EXP_ID_CODE_MOTION_PLUS_CLASSIC:
+        case EXP_ID_CODE_MOTION_PLUS_NUNCHUK:
+            wiiuse_motion_plus_handshake(wm, handshake_buf, EXP_HANDSHAKE_LEN);
+            wm->event = WIIUSE_MOTION_PLUS_ACTIVATED;
+            gotIt = 1;
+            break;
+
+        case EXP_ID_CODE_WII_BOARD:
+            if (wii_board_handshake(wm, &wm->exp.wb, handshake_buf, EXP_HANDSHAKE_LEN)) {
+                wm->event = WIIUSE_WII_BOARD_CTRL_INSERTED;
+                gotIt = 1;
+            }
+            break;
+
+        default:
+            WIIUSE_WARNING("Unknown expansion type. Code: 0x%x", id);
+            break;
+    }
+
+    free(handshake_buf);
+
+    if (gotIt) {
+        WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP_HANDSHAKE);
+        WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_EXP);
+    } else {
+        WIIUSE_WARNING("Could not handshake with expansion id: 0x%x", id);
+    }
+
+    wiiuse_set_ir_mode(wm);
+    wiiuse_set_report_type(wm);
+
+#if 0
 	WIIUSE_DEBUG("handshake_expansion with state %d", wm->expansion_state);
 
 	switch (wm->expansion_state) {
@@ -727,6 +837,7 @@ void handshake_expansion(struct wiimote_t* wm, byte* data, uint16_t len) {
 			wiiuse_status(wm);
 			break;
 	}
+#endif
 }
 
 

--- a/src/motion_plus.c
+++ b/src/motion_plus.c
@@ -182,7 +182,9 @@ static void wiiuse_set_motion_plus_clear1(struct wiimote_t *wm, byte *data, unsi
  *
  */
 void wiiuse_set_motion_plus(struct wiimote_t *wm, int status) {
-	byte val;
+    byte buf[MAX_PAYLOAD];
+    byte val;
+	int i;
 
 	if (!WIIMOTE_IS_SET(wm, WIIMOTE_STATE_MPLUS_PRESENT) ||
 	        WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP_HANDSHAKE)) {
@@ -190,13 +192,50 @@ void wiiuse_set_motion_plus(struct wiimote_t *wm, int status) {
 	}
 
 	if (status) {
+	    WIIUSE_DEBUG("Enabling Motion+\n");
+
 		WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_EXP_HANDSHAKE);
 		val = (status == 1) ? 0x04 : 0x05;
-		wiiuse_write_data_cb(wm, WM_EXP_MOTION_PLUS_ENABLE, &val, 1, wiiuse_motion_plus_handshake);
+		wiiuse_write_data(wm, WM_EXP_MOTION_PLUS_ENABLE, &val, 1);
+
+		wiiuse_millisleep(500); /* wait for M+ switch over */
+		wiiuse_motion_plus_handshake(wm, NULL, 0);
+
 	} else {
+	    WIIUSE_DEBUG("Disabling Motion+\n");
+
 		disable_expansion(wm);
 		val = 0x55;
-		wiiuse_write_data_cb(wm, WM_EXP_MEM_ENABLE1, &val, 1, wiiuse_set_motion_plus_clear1);
+		/* wiiuse_write_data_cb(wm, WM_EXP_MEM_ENABLE1, &val, 1, wiiuse_set_motion_plus_clear1); */
+		wiiuse_write_data(wm, WM_EXP_MEM_ENABLE1, &val, 1);
+		wiiuse_millisleep(500); /* wait for M+ switch over */
+
+		val = 0x0;
+		wiiuse_write_data(wm, WM_EXP_MEM_ENABLE1, &val, 1);
+		wiiuse_millisleep(500); /* wait for M+ switch over */
+
+	    WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP_FAILED);
+	    WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP_HANDSHAKE);
+	    wiiuse_set_ir_mode(wm);
+
+	    /*
+         * try to ask for status 3 times, sometimes the first one(s) gives bad data
+         * and doesn't show expansions - likely because the device didn't settle yet
+         */
+        for(i = 0; i < 3; ++i)
+        {
+            WIIUSE_DEBUG("Asking for status, attempt %d ...\n", i);
+            wm->event = WIIUSE_CONNECT;
+            wiiuse_status(wm);
+
+            wiiuse_wait_report(wm, WM_RPT_CTRL_STATUS, buf, MAX_PAYLOAD);
+
+            if(buf[3] != 0)
+                break;
+
+            wiiuse_millisleep(500);
+        }
+        propagate_event(wm, WM_RPT_CTRL_STATUS, buf + 1);
 	}
 }
 

--- a/src/wiiuse.c
+++ b/src/wiiuse.c
@@ -307,8 +307,9 @@ void wiiuse_motion_sensing(struct wiimote_t* wm, int status) {
  *	the current state of the device.
  */
 int wiiuse_set_report_type(struct wiimote_t* wm) {
-	byte buf[2];
-	int motion, exp, ir;
+
+    byte buf[2];
+	int motion, exp, ir, balance_board;
 
 	if (!wm || !WIIMOTE_IS_CONNECTED(wm)) {
 		return 0;
@@ -325,6 +326,7 @@ int wiiuse_set_report_type(struct wiimote_t* wm) {
 	motion = WIIMOTE_IS_SET(wm, WIIMOTE_STATE_ACC);
 	exp = WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP);
 	ir = WIIMOTE_IS_SET(wm, WIIMOTE_STATE_IR);
+	balance_board = exp && (wm->exp.type == EXP_WII_BOARD);
 
 	if (motion && ir && exp)	{
 		buf[1] = WM_RPT_BTN_ACC_IR_EXP;
@@ -336,6 +338,8 @@ int wiiuse_set_report_type(struct wiimote_t* wm) {
 		buf[1] = WM_RPT_BTN_IR_EXP;
 	} else if (ir) {
 		buf[1] = WM_RPT_BTN_ACC_IR;
+	} else if(exp && balance_board) {
+	    buf[1] = WM_RPT_BTN_EXP_8;
 	} else if (exp) {
 		buf[1] = WM_RPT_BTN_EXP;
 	} else if (motion) {

--- a/src/wiiuse_internal.h
+++ b/src/wiiuse_internal.h
@@ -122,6 +122,7 @@
 #define WM_RPT_WRITE				0x22
 #define WM_RPT_BTN					0x30
 #define WM_RPT_BTN_ACC				0x31
+#define WM_RPT_BTN_EXP_8            0x32
 #define WM_RPT_BTN_ACC_IR			0x33
 #define WM_RPT_BTN_EXP				0x34
 #define WM_RPT_BTN_ACC_EXP			0x35


### PR DESCRIPTION
Hello, 

I needed the balance board again and have discovered that the current code actually didn't work with mine at all :( I have added the missing report type and corrected the handshake.

At the same time I have made the expansion handshake synchronous. The main reason for that is that the wiiuse_write_data_cb() function actually doesn't work right - it depends on its callbacks being called when the report 0x22 (write ack) is received. Unfortunately, that report is not being sent by the hw consistently, making the write code hang and break, because the callback isn't called. For ex. my BigBen balance board almost never sends this report and thus was being detected maybe once in ten attempts. 

The current code is tested on Linux, with both the balance board, nunchuck and Motion Plus. I haven't touched any platform-specific code, so hopefully other platforms won't break. 

The wiiuse_write_data_cb() code can be probably removed, nothing seems to be using it anymore. BTW, the wiiuse_update() function doesn't seem to be used by anything neither (??). 

Regards,

Jan

