### PR TITLE
fixed EXP_ID_CODE overflow

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -626,7 +626,7 @@ static void handle_expansion(struct wiimote_t* wm, byte* msg) {
  *	a handshake with the expansion.
  */
 void handshake_expansion(struct wiimote_t* wm, byte* data, uint16_t len) {
-	int id;
+	uint32_t id;
 	byte val = 0;
 	byte buf = 0x00;
 	byte* handshake_buf;


### PR DESCRIPTION
on a 32-bit machine `int` type cannot store `EXP_ID_CODE`'s without overflow.