### PR TITLE
added malloc casts

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -661,7 +661,7 @@ void handshake_expansion(struct wiimote_t* wm, byte* data, uint16_t len) {
 			if (WIIMOTE_IS_SET(wm, WIIMOTE_STATE_EXP)) {
 				disable_expansion(wm);
 			}
-			handshake_buf = malloc(EXP_HANDSHAKE_LEN * sizeof(byte));
+			handshake_buf = (byte*)malloc(EXP_HANDSHAKE_LEN * sizeof(byte));
 			/* tell the wiimote to send expansion data */
 			WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_EXP);
 			wiiuse_read_data_cb(wm, handshake_expansion, handshake_buf, WM_EXP_MEM_CALIBR, EXP_HANDSHAKE_LEN);

--- a/src/events.c
+++ b/src/events.c
@@ -626,7 +626,7 @@ static void handle_expansion(struct wiimote_t* wm, byte* msg) {
  *	a handshake with the expansion.
  */
 void handshake_expansion(struct wiimote_t* wm, byte* data, uint16_t len) {
-	int id;
+	uint32_t id;
 	byte val = 0;
 	byte buf = 0x00;
 	byte* handshake_buf;

--- a/src/guitar_hero_3.c
+++ b/src/guitar_hero_3.c
@@ -80,7 +80,7 @@ int guitar_hero_3_handshake(struct wiimote_t* wm, struct guitar_hero_3_t* gh3, b
 		 */
 		if (data[16] == 0xFF) {
 			/* get the calibration data */
-			byte* handshake_buf = malloc(EXP_HANDSHAKE_LEN * sizeof(byte));
+			byte* handshake_buf = (byte*)malloc(EXP_HANDSHAKE_LEN * sizeof(byte));
 
 			WIIUSE_DEBUG("Guitar Hero 3 handshake appears invalid, trying again.");
 			wiiuse_read_data_cb(wm, handshake_expansion, handshake_buf, WM_EXP_MEM_CALIBR, EXP_HANDSHAKE_LEN);

--- a/src/wiiuse.c
+++ b/src/wiiuse.c
@@ -135,10 +135,10 @@ struct wiimote_t** wiiuse_init(int wiimotes) {
 		return NULL;
 	}
 
-	wm = malloc(sizeof(struct wiimote_t*) * wiimotes);
+	wm = (struct wiimote_t**)malloc(sizeof(struct wiimote_t*) * wiimotes);
 
 	for (i = 0; i < wiimotes; ++i) {
-		wm[i] = malloc(sizeof(struct wiimote_t));
+		wm[i] = (struct wiimote_t*)malloc(sizeof(struct wiimote_t));
 		memset(wm[i], 0, sizeof(struct wiimote_t));
 
 		wm[i]->unid = i + 1;


### PR DESCRIPTION
These casts were required to make the project compile with clang-600.0.56 on OS X 10.9.5.