### PR TITLE
Nintendo RVL-CNT-01-TR support on Windows

### DIFF
--- a/src/os_win.c
+++ b/src/os_win.c
@@ -111,7 +111,8 @@ int wiiuse_os_find(struct wiimote_t** wm, int max_wiimotes, int timeout) {
 		attr.Size = sizeof(attr);
 		i = HidD_GetAttributes(dev, &attr);
 
-		if ((attr.VendorID == WM_VENDOR_ID) && (attr.ProductID == WM_PRODUCT_ID)) {
+		if ((attr.VendorID == WM_VENDOR_ID) && ((attr.ProductID == WM_PRODUCT_ID) || (attr.ProductID == WM_PRODUCT_ID_TR)))
+		{
 			/* this is a wiimote */
 			wm[found]->dev_handle = dev;
 

--- a/src/wiiuse_internal.h
+++ b/src/wiiuse_internal.h
@@ -161,6 +161,7 @@
 #endif
 #define WM_VENDOR_ID				0x057E
 #define WM_PRODUCT_ID				0x0306
+#define WM_PRODUCT_ID_TR		0x0330
 
 /* controller status stuff */
 #define WM_MAX_BATTERY_CODE			0xC8


### PR DESCRIPTION
Added Nintendo RVL-CNT-01-TR support for Windows. Only little changes to recognize the new WiiMotes with their product id. Modifications are tested on Windows, everything seems to work well.