### PR TITLE
Removed WinHID search.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,6 @@ else()
 endif()
 
 if(WIN32)
-	find_package(WinHID REQUIRED)
-	include_directories(${WINHID_INCLUDE_DIRS})
 	if(MSVC)
 		# Minimum requirement is WinXP
 		add_definitions(-D_WIN32_WINNT=0x0501)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ add_definitions(-DWIIUSE_COMPILE_LIB)
 add_library(wiiuse ${WIIUSE_LIB_TYPE} ${SOURCES} ${API})
 
 if(WIN32)
-	target_link_libraries(wiiuse ws2_32 setupapi ${WINHID_LIBRARIES})
+	target_link_libraries(wiiuse ws2_32 setupapi hid)
 elseif(LINUX)
 	target_link_libraries(wiiuse m rt ${BLUEZ_LIBRARIES})
 elseif(APPLE)


### PR DESCRIPTION
The WinHID includes and libraries are part of the WinSDK 8.1+, no need to search for them.

The code, as given, builds out of the box with MSVC2013 Community Edition.