### PR TITLE
Fixed warnings generated by MSVC2013.

### DIFF
--- a/src/definitions_os.h
+++ b/src/definitions_os.h
@@ -41,11 +41,14 @@
 
 #ifdef _MSC_VER
 	#include <float.h>
-	/* windows with visual c */
-	#define isnan(x)		(_isnan(x))
-	#define isinf(x)		(!_finite(x))
-	/* disable warnings I don't care about */
-	/*#pragma warning(disable:4273)	*/	/* inconsistent dll linkage			*/
+	#include <math.h>
+	/* windows with old visual c doesn't have isXYZ macros */
+	#ifndef isnan
+		#define isnan(x)		(_isnan(x))
+	#endif
+	#ifndef isinf
+		#define isinf(x)		(!_finite(x))
+	#endif
 #endif
 
 #endif /* DEFINITIONS_OS_H_INCLUDED */


### PR DESCRIPTION
The macros are already defined in math.h, no need to redefine them.