### PR TITLE
Travis CI: Fix Mac OS X build

### DIFF
--- a/scripts/ci/osx/install.sh
+++ b/scripts/ci/osx/install.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -ev
+unset -f cd # See https://github.com/travis-ci/travis-ci/issues/8703
 
-brew install cmake 
+brew update
+brew ls --versions cmake && brew upgrade cmake || brew install cmake # Install or Update cmake (if required)


### PR DESCRIPTION
I'm not sure if the Travis CI integration is still active for the master branch but this pull request will fix the [broken build routine](https://travis-ci.org/rpavlik/wiiuse/builds/225397149) on/for Mac OS X. For detailed build log, please refer to [here](https://travis-ci.org/Baumgartl/wiiuse/builds/369082047?utm_source=github_status&utm_medium=notification).